### PR TITLE
Set up about page with Luiz Ladeira's content and identity

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,23 +3,22 @@
 # -----------------------------------------------------------------------------
 
 title: blank # the website title (if blank, full name will be used instead)
-first_name: You
-middle_name: R.
-last_name: Name
+first_name: Luiz
+middle_name: Maia
+last_name: Ladeira
 contact_note: >
-  You can even add a little note about which of these is the best way to reach you.
+  Email is the best way to reach me.
 description: > # the ">" symbol means to ignore newlines until "footer_text:"
-  A simple, whitespace theme for academics. Based on [*folio](https://github.com/bogoli/-folio) design.
+  Postdoctoral researcher in systems biology and toxicology at the GIGA Institute, University of Liège.
 footer_text: >
   Powered by <a href="https://jekyllrb.com/" target="_blank">Jekyll</a> with <a href="https://github.com/alshedivat/al-folio">al-folio</a> theme.
   Hosted by <a href="https://pages.github.com/" target="_blank">GitHub Pages</a>.
-  Photos from <a href="https://unsplash.com" target="_blank">Unsplash</a>.
-keywords: jekyll, jekyll-theme, academic-website, portfolio-website # add your own keywords or leave empty
+keywords: toxicology, systems biology, physiological maps, disease maps, SBGN, in silico methods, academic-website # add your own keywords or leave empty
 lang: en # the language of your site (for example: en, fr, cn, ru, etc.)
-icon: ⚛️ # the emoji used as the favicon (alternatively, provide image name in /assets/img/)
+icon: 🧬 # the emoji used as the favicon (alternatively, provide image name in /assets/img/)
 
-url: https://alshedivat.github.io # the base hostname & protocol for your site
-baseurl: /al-folio # the subpath of your site, e.g. /blog/. Leave blank for root
+url: https://luiz-ladeira.github.io # the base hostname & protocol for your site
+baseurl: "" # the subpath of your site, e.g. /blog/. Leave blank for root
 last_updated: false # set to true if you want to display last updated in the footer
 impressum_path: # set to path to include impressum link in the footer, use the same path as permalink in a page, helps to conform with EU GDPR
 back_to_top: true # set to false to disable the back to top button

--- a/_data/socials.yml
+++ b/_data/socials.yml
@@ -1,14 +1,12 @@
 # this file contains the social media links and usernames of the author
 # the socials will be displayed in the order they are defined here
 # for more information, please refer to the documentation of jekyll-socials plugin: https://github.com/george-gca/jekyll-socials
-cv_pdf: /assets/pdf/example_pdf.pdf # path to your CV PDF file
-email: you@example.com # your email address
-inspirehep_id: 1010907 # Inspire HEP author ID
-rss_icon: true # comment this line to hide the RSS icon
-scholar_userid: qc6CJjYAAAAJ # your Google Scholar ID
-# wechat_qr: # filename of your wechat qr-code saved as an image (e.g., wechat-qr.png if saved to assets/img/wechat-qr.png)
-# whatsapp_number: # your WhatsApp number (full phone number in international format. Omit any zeroes, brackets, or dashes when adding the phone number in international format.)
-custom_social: # can be any name here other than the ones already defined in the jekyll-socials plugin
-  logo: https://www.alberteinstein.com/wp-content/uploads/2024/03/cropped-favicon-192x192.png # can be png, svg, jpg
-  title: Custom Social
-  url: https://www.alberteinstein.com/
+email: luizmaialadeira@gmail.com # your email address
+rss_icon: false # set to true to show the RSS icon
+# --- Fill these in with your own profiles, then uncomment the lines you want shown ---
+# cv_pdf: /assets/pdf/cv.pdf # path to your CV PDF file (drop the file in assets/pdf/)
+# scholar_userid: # your Google Scholar ID (the value after "user=" in your Scholar profile URL)
+# orcid_id: # your ORCID iD (e.g., 0000-0000-0000-0000)
+# linkedin_username: # your LinkedIn username
+# github_username: luiz-ladeira # your GitHub username
+# researchgate_profile: # your ResearchGate profile name

--- a/_data/socials.yml
+++ b/_data/socials.yml
@@ -1,12 +1,13 @@
 # this file contains the social media links and usernames of the author
 # the socials will be displayed in the order they are defined here
 # for more information, please refer to the documentation of jekyll-socials plugin: https://github.com/george-gca/jekyll-socials
-email: luizmaialadeira@gmail.com # your email address
-rss_icon: false # set to true to show the RSS icon
-# --- Fill these in with your own profiles, then uncomment the lines you want shown ---
-# cv_pdf: /assets/pdf/cv.pdf # path to your CV PDF file (drop the file in assets/pdf/)
-# scholar_userid: # your Google Scholar ID (the value after "user=" in your Scholar profile URL)
-# orcid_id: # your ORCID iD (e.g., 0000-0000-0000-0000)
-# linkedin_username: # your LinkedIn username
-# github_username: luiz-ladeira # your GitHub username
-# researchgate_profile: # your ResearchGate profile name
+email: luizmaialadeira@gmail.com
+github_username: luiz-ladeira
+linkedin_username: luizladeira
+scholar_userid: 8pFoo94AAAAJ
+# lattes_id: 6144420994544611 # Lattes CV ID (if supported by jekyll-socials, add to plugin docs)
+rss_icon: false
+# --- Other profiles you can uncomment and fill in ---
+# orcid_id: # ORCID iD (e.g., 0000-0000-0000-0000)
+# researchgate_profile: # ResearchGate username
+# work_url: # Personal/lab website URL

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -6,7 +6,7 @@ subtitle: Postdoctoral Researcher at the <a href='http://www.biomech.ulg.ac.be/'
 
 profile:
   align: right
-  image: prof_pic.jpg
+  image: prof_pic_color.png
   image_circular: true # crops the image to make it circular
   more_info:
 

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -2,33 +2,34 @@
 layout: about
 title: about
 permalink: /
-subtitle: <a href='#'>Affiliations</a>. Address. Contacts. Motto. Etc.
+subtitle: Postdoctoral Researcher at the <a href='http://www.biomech.ulg.ac.be/'>Biomechanics Research Unit</a>, <a href='https://www.giga.uliege.be/cms/c_4113263/fr/giga'>GIGA Institute</a> &middot; <a href='https://www.uliege.be/cms/c_8699436/en/uliege'>University of Liège</a>, Belgium.
 
 profile:
   align: right
   image: prof_pic.jpg
-  image_circular: false # crops the image to make it circular
-  more_info: >
-    <p>555 your office number</p>
-    <p>123 your address street</p>
-    <p>Your City, State 12345</p>
+  image_circular: true # crops the image to make it circular
+  more_info:
 
-selected_papers: true # includes a list of papers marked as "selected={true}"
+selected_papers: false # includes a list of papers marked as "selected={true}"
 social: true # includes social icons at the bottom of the page
 
 announcements:
-  enabled: true # includes a list of news items
+  enabled: false # includes a list of news items
   scrollable: true # adds a vertical scroll bar if there are more than 3 news items
   limit: 5 # leave blank to include all the news in the `_news` folder
 
 latest_posts:
-  enabled: true
+  enabled: false
   scrollable: true # adds a vertical scroll bar if there are more than 3 new posts items
   limit: 3 # leave blank to include all the blog posts
 ---
 
-Write your biography here. Tell the world about yourself. Link to your favorite [subreddit](https://www.reddit.com). You can put a picture in, too. The code is already in, just name your picture `prof_pic.jpg` and put it in the `img/` folder.
+Hi there! My name is Luiz and I'm a postdoctoral researcher at the [Biomechanics Research Unit](http://www.biomech.ulg.ac.be/) at the [GIGA Institute - Molecular & Computational Biology](https://www.giga.uliege.be/cms/c_4113263/fr/giga), part of the [University of Liège](https://www.uliege.be/cms/c_8699436/en/uliege), in Belgium, since 2021, under the supervision of [Prof. Liesbet Geris](http://www.biomech.ulg.ac.be/team/liesbet-geris/). I'm currently working on the [ONTOX project](https://ontox-project.eu/), designing molecular interaction pathway maps, which we call [Physiological Maps](https://sites.google.com/view/ontox-maps/). But I also collaborate on various other systems biology and toxicology projects.
 
-Put your address / P.O. box / other info right below your picture. You can also disable any of these elements by editing `profile` property of the YAML header of your `_pages/about.md`. Edit `_bibliography/papers.bib` and Jekyll will render your [publications page](/al-folio/publications/) automatically.
+Before I joined the Biomechanics Research Unit, I did my MSc and PhD in [Cell and Structural Biology](http://www.biocel.ufv.br/) from the [Federal University of Viçosa](https://www.ufv.br/) (UFV), in Brazil (2015-2021). During that period, my research was focused on toxicological and therapeutic effects of phytochemicals from native and exotic plant species in different _in vivo_ models of metabolic diseases, such as liver steatosis and type 1 diabetes nephropathy and cardiomyopathy. I worked in the Laboratory of Structural Biology under the supervision of [Prof. Izabel Maldonado](http://lattes.cnpq.br/2912503249825088) for 6.5 years. I also collaborated on different environmental and reproductive toxicology projects and food and nutrition projects in different _in vivo_ models and human patients.
 
-Link to your social media connections, too. This theme is set up to use [Font Awesome icons](https://fontawesome.com/) and [Academicons](https://jpswalsh.github.io/academicons/), like the ones below. Add your Facebook, Twitter, LinkedIn, Google Scholar, or just disable all of them.
+I am a positive, flexible and resilient person, passionate about learning new things and applying them to solve problems. I also like to share what I learn, and because of that, I engaged as a Volunteer Professor at [Ludic Course of Cell Biology and Histology](https://orbi.uliege.be/bitstream/2268/297626/1/MARRIEL%20et%20al.%20-%202021%20-%20O%20l%C3%BAdico%20no%20ensino%20de%20biologia%20celular%20possibilidades%20no%20ensino%20superior%20-%20Revista%20ELO%20%E2%80%93%20Di%C3%A1logos%20em%20Extens%C3%A3o.pdf), developing and utilizing active methods in education to help more than 300 students from various undergrad courses during the 2 years I was there. As a postgrad student, I served as a representative for my colleagues in the Coordination Committee of my program from 2017 to 2019. With my colleagues, I created the first [Summer School in Cell and Structural Biology](https://www2.dti.ufv.br/noticias/scripts/exibeNoticiaMulti.php?codNot=38980) from UFV in 2017 and helped in the organization of 2 following editions.
+
+At the University of Liège, in addition to ONTOX, I have the opportunity to actively volunteer at the [VPH Institute](https://www.vph-institute.org/) and the [Avicenna Alliance](https://www.avicenna-alliance.com/), in which I contribute to advocating for _in silico_ methods in healthcare and research. I'm also an active member of the [Disease Maps](http://disease-maps.github.io/) and [SBGN](https://sbgn.github.io/) communities - currently serving as SBGN editor (2025-2027). And since October 2024, I joined the [European Society of Toxicology In Vitro](https://www.estiv.org/) as a board member to keep spreading the word of _in silico_ methods as non-animal alternatives in science.
+
+_Some of my research interests include (but are not limited to):_ Toxicology, Physiology, Physiological Maps, Disease Maps, SBGN, Cardiology, Cardiotoxicity, Nephrotoxicity, Metabolism, Cell Signaling, Gene Regulation, Ontologies, Adverse Outcome Pathways, Dynamic Modeling, Digital Twins, Networks, Developmental Biology, Hepatology, Immunology, Open Science & FAIR.


### PR DESCRIPTION
Replace the al-folio starter placeholders on the home/about page with real bio, affiliation, and research interests. Update site identity (name, description, keywords, favicon), point url at the user GitHub Pages domain, set baseurl to root, and clean Einstein placeholders out of socials.yml (real email + commented templates for the rest).


Claude-Session: https://claude.ai/code/session_01HY5kb55QxNpXNopRqR2M1S

## Summary

Describe what changed and why.

## Ownership Routing

- [ ] I confirmed this PR targets the correct repo based on `docs/BOUNDARIES.md`.
- [ ] This PR only changes starter-owned scope (`al-folio`) **or** I am porting a routed change and linked the owning repo issue/PR.

Owning repo (if not starter): <!-- e.g., al-org-dev/al-folio-core -->
Related issue/PR: <!-- link -->

## Plugin Ecosystem (if applicable)

- [ ] Not applicable
- [ ] This PR proposes a plugin for **featured-only** listing.
- [ ] This PR proposes a plugin for **bundled** starter inclusion.

If plugin-related, provide:

- Plugin repo URL:
- Gem name:
- Jekyll plugin id:
- Compatibility (`al_folio_min`/`al_folio_max`):
- Demo page/post path:
- Maintainer contact:

## Starter Wiring Changes

- [ ] Not applicable
- [ ] Updated `Gemfile` dependency wiring.
- [ ] Updated `_config.yml` plugin activation/config.
- [ ] Updated `_data/featured_plugins.yml` metadata.

## Validation

- [ ] `npm ci`
- [ ] `bundle exec jekyll build`
- [ ] `npm run lint:prettier`
- [ ] `npm run lint:style-contract`
- [ ] Integration tests (`test/integration_*.sh`) as needed
- [ ] Visual tests (`npm run test:visual`) as needed

## Notes

Compatibility, migration implications, and follow-ups:
